### PR TITLE
Ensure white text in dark mode

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,3 +5,8 @@
 html {
   @apply bg-white text-gray-800 dark:bg-gray-900 dark:text-white;
 }
+
+/* Ensure all text appears white in dark mode */
+* {
+  @apply dark:text-white;
+}


### PR DESCRIPTION
## Summary
- make all text white when dark mode is active by applying `dark:text-white` globally
